### PR TITLE
Fix pagination 'next' link

### DIFF
--- a/src/components/pagination/pagination-block/pagination-block.tsx
+++ b/src/components/pagination/pagination-block/pagination-block.tsx
@@ -3,6 +3,7 @@ import { MoviesDataSchema } from '@schemas';
 import type { MoviesPromiseProps } from '@ts-interfaces';
 import { use } from 'react';
 
+import { API_CONFIG } from '@/api.config';
 import { createPages } from '@/utils/create-pages';
 
 import styles from './pagination-block.module.css';
@@ -31,7 +32,7 @@ export const PaginationBlock: React.FC<MoviesPromiseProps> = ({
       <PaginationEdges
         previousPage={currentPage - 1}
         nextPage={currentPage + 1}
-        pages={pages}
+        totalPages={Math.ceil(totalResults / API_CONFIG.ITEMS_PER_PAGE)}
         searchTerm={searchTerm}
       >
         {pages.map((page, index) => {

--- a/src/components/pagination/pagination-edges/pagination-edges.tsx
+++ b/src/components/pagination/pagination-edges/pagination-edges.tsx
@@ -11,7 +11,7 @@ import styles from './pagination-edges.module.css';
 interface PaginationEdges {
   previousPage: number;
   nextPage: number;
-  pages: (number | '...')[];
+  totalPages: number;
   searchTerm: string;
 }
 
@@ -19,7 +19,7 @@ export const PaginationEdges: React.FC<PropsWithChildren<PaginationEdges>> = ({
   children,
   previousPage,
   nextPage,
-  pages,
+  totalPages,
   searchTerm,
 }) => {
   return (
@@ -38,7 +38,7 @@ export const PaginationEdges: React.FC<PropsWithChildren<PaginationEdges>> = ({
       </div>
       {children}
       <div className={styles.paginationEdge}>
-        {nextPage <= pages.length ? (
+        {nextPage <= totalPages ? (
           <NavLink
             data-testid="next-page"
             to={`?s=${searchTerm}&page=${nextPage}`}


### PR DESCRIPTION
# Description

The 'next' link depended on `pages.length` which was not a correct condition to show it. 'pages' doesn't contain an array of full pages, but a transformed shortened array for ui display.

## Related Task

N / A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration
- [ ] Code refactoring
- [ ] Documentation
- [ ] Other:

## Time Log

~ 15 min
